### PR TITLE
pydanticを用いたjsonレスポンスの検証を行う

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
+          - pydantic
           - types-requests
         files: ^westjr/
         args: [--strict]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ keywords =
 [options]
 packages = find:
 install_requires =
+    pydantic>=1.10.4
     requests>=2.26.0
     types-requests>=2.27.11
     typing-extensions>=4.2.0
@@ -53,6 +54,7 @@ per-file-ignores =
     example.py:E501
 
 [mypy]
+plugins = pydantic.mypy
 python_version = 3.9
 show_error_codes = True
 pretty = True

--- a/westjr/api.py
+++ b/westjr/api.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from typing import cast
 
 import requests
-from requests import RequestException
+
+from westjr.utils import parse_data_from_typeddict
 
 from .const import AREAS, LINES, STATIONS, STOP_TRAINS
 from .response_types import (
@@ -33,11 +34,10 @@ class WestJR:
             res = requests.get(url=uri)
             try:
                 res.raise_for_status()
-            except RequestException as e:
+            except requests.RequestException as e:
                 print(e)
                 raise e
             res_dict = res.json()
-            # print(f"[{endpoint}, {uri}]\n{res_dict}", file=open(".log", "a"))
             return cast(ResponseDict, res_dict)
         else:
             return None
@@ -58,7 +58,7 @@ class WestJR:
         if res is None:
             raise ValueError("Response is empty.")
 
-        return cast(AreaMaster, res)
+        return parse_data_from_typeddict(AreaMaster, res)
 
     def get_stations(self, line: str | None = None) -> Stations:
         """
@@ -75,7 +75,7 @@ class WestJR:
         if res is None:
             raise ValueError("Response is empty.")
 
-        return cast(Stations, res)
+        return parse_data_from_typeddict(Stations, res)
 
     def get_trains(self, line: str | None = None) -> TrainPos:
         """
@@ -90,7 +90,7 @@ class WestJR:
         if res is None:
             raise ValueError("Response is empty.")
 
-        return cast(TrainPos, res)
+        return parse_data_from_typeddict(TrainPos, res)
 
     def get_maintenance(self, area: str | None = None) -> AreaMaintenance:
         """
@@ -105,18 +105,8 @@ class WestJR:
         res = self._request(endpoint=endpoint)
         if res is None:
             raise ValueError("Response is empty")
-        return cast(AreaMaintenance, res)
 
-    def get_train_monitor_info(self) -> TrainMonitorInfo:
-        """
-        列車の環境を取得して返す．
-        :return: dict
-        """
-        endpoint = "trainmonitorinfo"
-        res = self._request(endpoint=endpoint)
-        if res is None:
-            raise ValueError("Response is empty")
-        return cast(TrainMonitorInfo, res)
+        return parse_data_from_typeddict(AreaMaintenance, res)
 
     def get_traffic_info(self, area: str | None = None) -> TrainInfo:
         """
@@ -132,7 +122,19 @@ class WestJR:
         if res is None:
             raise ValueError("Response is empty.")
 
-        return cast(TrainInfo, res)
+        return parse_data_from_typeddict(TrainInfo, res)
+
+    def get_train_monitor_info(self) -> TrainMonitorInfo:
+        """
+        列車の環境を取得して返す．
+        :return: dict
+        """
+        endpoint = "trainmonitorinfo"
+        res = self._request(endpoint=endpoint)
+        if res is None:
+            raise ValueError("Response is empty")
+
+        return parse_data_from_typeddict(TrainMonitorInfo, res)
 
     def convert_stopTrains(self, stopTrains: list[int] | None = None) -> list[str]:
         """

--- a/westjr/utils.py
+++ b/westjr/utils.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Any, TypeVar, cast
+
+from pydantic import create_model_from_typeddict
+
+_T = TypeVar("_T")
+
+
+def parse_data_from_typeddict(typeddict_cls: type[_T], data: Any) -> _T:
+    Model = create_model_from_typeddict(typeddict_cls)
+    m = Model(**data).dict()
+    return cast(_T, m)
+
+
+__all__ = ("parse_data_from_typeddict",)


### PR DESCRIPTION
Closes: #33 

Pydanticを用いて、JSONレスポンスがTypedDictによるスキーマに対して適合しているか確認するようにしました。

Pydantic の型付けが弱く、 `FooDictModel(**res).dict()` は `dict[str, Any]` になるため引き続き `cast` を用いていますが、もし不適合の場合:

```
E   pydantic.error_wrappers.ValidationError: 1 validation error for Stations
E   stations
E     field required (type=value_error.missing)

pydantic/main.py:342: ValidationError
```

のような `pydantic.ValidationError` エラーが発生します。