### PR TITLE
Test CIのPythonバージョンを3.7から3.8に変更する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, "3.10"]
+        python-version: ["3.8", "3.10"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
https://github.com/unyacat/westjr/pull/45

にて、Pyupgradeにより、EOLを迎えた3.7が最小要件から外されCIが落ちています。

https://github.com/unyacat/westjr/actions/runs/5512544184/jobs/10049512891#step:4:873

そのためCIでテストするPythonバージョンを「3.7 と 3.10」から「3.8　と 3.10」に変更しました。