### PR TITLE
`SideItem.line` で `None` を許容する

### DIFF
--- a/westjr/response_types/stations.py
+++ b/westjr/response_types/stations.py
@@ -28,7 +28,7 @@ class SideItem(BaseModel):
     side: Optional[int]
     linkLine: Optional[str]
     linkStationCode: Optional[str]
-    line: str
+    line: Optional[str]
     linkDirection: Optional[int]
 
 


### PR DESCRIPTION
Fix: #44

Ref:
https://web.archive.org/web/20230713074259/https://www.train-guide.westjr.co.jp/api/v3/osakaloop_st.json